### PR TITLE
HIstory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# New-Test
+The Defenestration of Prague (1618)
+
+In this bizarre and pivotal moment in European history, a group of Protestant nobles threw two Catholic officials out of a third-story window of Prague Castle. Remarkably, the officials survived—allegedly by landing in a pile of manure. This act of defiance helped spark the Thirty Years' War, one of the most destructive conflicts in European history.# New-Test
 Repository for testing GitHub flow


### PR DESCRIPTION
The Great Emu War (1932) – Australia

In 1932, the Australian government declared war… on emus.

After World War I, Australian veterans were given farmland in Western Australia. But emus—large flightless birds—started invading these farms in huge numbers, damaging crops. The military was sent in with machine guns to control them.

The result? The emus won. They were too fast and scattered, and the operation was eventually abandoned after a series of embarrassing failures.

It’s often cited as one of history’s most absurd military campaigns.